### PR TITLE
New Modules & Dependencies: ES6 Restructuring, Rest operators, classNames utility 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties', 'react-hot-loader/babel']
+  "plugins": ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties', 'react-hot-loader/babel', 'transform-es2015-destructuring', 'transform-object-rest-spread']
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "homepage": "https://github.com/alicoding/react-webpack-babel#readme",
   "dependencies": {
+    "classnames": "^2.2.5",
     "node-sass": "^3.13.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",
@@ -26,6 +27,8 @@
     "babel-loader": "6.2.7",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+    "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-react": "6.16.0",

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -1,6 +1,6 @@
 module.exports = [
 	{
-		test: /\.jsx?$/,
+		test: /\.js?$/,
 		exclude: /(node_modules|bower_components|public)/,
 		loader: "babel"
 	},


### PR DESCRIPTION
This PR will transition the development environment to support a more fluid structure that is conducive to the development approach: 
- Include a dependency on the rest spread operator. This approach is defined within a [GH issue in the Babel repository](https://github.com/babel/babel-loader/issues/170#issuecomment-257197385) 
  - This will be used primarily as a prop from within generic components. Within this methodology, we can create generic components that will accept properties from where they're called in. This will be really beneficial for instances of when we want to nest generic components within reusable components. FaceBook expands on this prop [here](https://facebook.github.io/react/docs/jsx-in-depth.html#spread-attributes).
- The addition of [Jed Waton's classNames module](https://github.com/JedWatson/classnames), which will be a big help with handling class designation on a conditional basis. This can be done in a longer-form, but this library really simplifies the process. 
- Modifying the WebPack loaders to target `.js` files instead of `.jsx`. I should've updated this last night when I migrated all `.jsx` files over to `.js`. 