### PR TITLE
Generic Link Component 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties', 'react-hot-loader/babel']
+  "plugins": ['transform-runtime', 'transform-decorators-legacy', 'transform-class-properties', 'react-hot-loader/babel', 'transform-es2015-destructuring', 'transform-object-rest-spread']
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "homepage": "https://github.com/alicoding/react-webpack-babel#readme",
   "dependencies": {
+    "classnames": "^2.2.5",
     "node-sass": "^3.13.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",
@@ -26,6 +27,8 @@
     "babel-loader": "6.2.7",
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+    "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-react": "6.16.0",

--- a/src/components/Link/Link.css
+++ b/src/components/Link/Link.css
@@ -1,0 +1,3 @@
+a {
+  color: green;
+}

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -11,7 +11,7 @@ class Link extends Component {
     } = this.props;
 
     return (
-      <a href={href} {...others}>
+      <a className={variant} href={href} {...others}>
         {children}
       </a>
     );

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import styles from './Link.css';
 
 class Link extends Component {
@@ -17,5 +17,11 @@ class Link extends Component {
     );
   }
 }
+
+Link.propTypes = {
+  href: React.PropTypes.string,
+  children: React.PropTypes.any,
+  variant: React.PropTypes.string,
+};
 
 export default Link;

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import styles from './Link.css';
+
+class Link extends Component {
+  render() {
+    const { 
+      href,
+      children,
+      variant,
+      ...others
+    } = this.props;
+
+    return (
+      <a href={href} {...others}>
+        {children}
+      </a>
+    );
+  }
+}
+
+export default Link;

--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import styles from './PortfolioApp.css';
 import Image from '../Image';
+import Link from '../Link';
 
 class PortfolioApp extends Component {
   render() {
@@ -8,8 +9,7 @@ class PortfolioApp extends Component {
       <div className={styles.PortfolioApp}>
         <Image src="https:unsplash.it/700/400" />
         <h1 className={styles.header}>It Works!</h1>
-        <p>This React project just works including <span className={styles.redBg}>module</span> local styles.</p>
-        <p>A work in progess by Jesse!</p>
+        <p>A work in progess by Jesse! Follow me on <Link href="https://github.com/JesseNoseworthy">GitHub</Link></p>
       </div>
     )
   }

--- a/webpack.loaders.js
+++ b/webpack.loaders.js
@@ -1,6 +1,6 @@
 module.exports = [
 	{
-		test: /\.jsx?$/,
+		test: /\.js?$/,
 		exclude: /(node_modules|bower_components|public)/,
 		loader: "babel"
 	},


### PR DESCRIPTION
This PR is dependant on https://github.com/JesseNoseworthy/react_portfolio/pull/3, which includes the necessary infrastructure for the spread operator used as a prop in the `<Link>` component being created.

A generic component is being created here that will hold an anchor tag. I'm also including a few properties:
- `href`: simply the `href` for the `<a>` tag
- `children`: more on this [here](https://facebook.github.io/react/docs/composition-vs-inheritance.html)
- `variant`: this will allow for us to assign a custom class name when we import the component. In the future we can use this to handle a variety of different link types and hold the styles in the `Link.css` file created in this PR

This component also uses typechecking to validate the value being passed into the above props. Read more about this [here](https://facebook.github.io/react/docs/typechecking-with-proptypes.html).