### PR TITLE
Global Styles CSS folder in ../src

### DIFF
--- a/src/app/template.html
+++ b/src/app/template.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Jesse Noseworthy | Developer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Raleway:400,600,700" rel="stylesheet">
 </head>
 <body>
   <div id="app">Loading...</div>

--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import styles from './PortfolioApp.css';
+import globalStyles from '../../globalStyles/index.css';
 import Image from '../Image';
 import Link from '../Link';
 import Button from '../Button';

--- a/src/globalStyles/index.css
+++ b/src/globalStyles/index.css
@@ -1,0 +1,2 @@
+@import './variables.css';
+@import './typography.css';

--- a/src/globalStyles/typography.css
+++ b/src/globalStyles/typography.css
@@ -1,0 +1,16 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--header-font-family);
+}
+
+li,
+a,
+p,
+dt,
+dd {
+  font-family: var(--base-font-family);
+}

--- a/src/globalStyles/variables.css
+++ b/src/globalStyles/variables.css
@@ -1,0 +1,4 @@
+:root {
+  --header-font-family: 'Raleway', 'Arial', sans-serif;
+  --base-font-family: 'Open Sans Condensed', sans-serif;
+}


### PR DESCRIPTION
This PR adds in a `../globalStyles` folder into `../src`, which will hold some global stylesheets such as a CSS reset, typography, variables, etc...

I'm not too fond of the `globalStyles` folder name, as I feel that some styles held here may not be global. With that being said, I don't want to name it `styles` as that would contradict the component-based styles I'm currently developing.

I plan on refactoring this approach in the very near future, and aim to find a more semantic structure.