### PR TITLE
SocialIcon component 

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,5 +1,5 @@
 // All Link styles go here
 
 a {
-  color: green;
+
 }

--- a/src/components/SocialIcon/SocialIcon.scss
+++ b/src/components/SocialIcon/SocialIcon.scss
@@ -1,0 +1,5 @@
+@import url('https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css');
+
+.socialIcon {
+
+}

--- a/src/components/SocialIcon/index.js
+++ b/src/components/SocialIcon/index.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import styles from './SocialIcon.scss';
+import classNames from 'classnames';
+import FontAwesome from 'react-fontawesome';
+import Link from '../Link';
+
+class SocialIcon extends Component {
+  render() {
+    const {
+      socialUrl,
+      variant,
+      iconType,
+      iconSize,
+      ...others
+    } = this.props
+
+    const iconClass = classNames(styles.socialIcon, styles[variant]);
+
+    return (
+      <Link href={socialUrl} {...others}>
+        <FontAwesome
+          className={iconClass}
+          name={iconType}
+          size={iconSize}
+         />
+      </Link>
+    )
+  }
+}
+
+SocialIcon.propTypes = {
+  socailUrl: React.PropTypes.string,
+  variant: React.PropTypes.string,
+  iconType: React.PropTypes.string.isRequired,
+  iconSize: React.PropTypes.any,
+}
+
+SocialIcon.getDefaultProps = {
+  iconType: 'facebook',
+  iconSize: '2x'
+}
+
+export default SocialIcon;


### PR DESCRIPTION
Utilizing the [react-font-awesome](https://github.com/danawoodman/react-fontawesome) module, this PR adds in a SocialIcon component. 

Although the component creates the ability to render a FontAwesome icon, the styles CDN still needs to be hosted locally; so I've stored it directly in the `SocialIcon.scss` file. I feel this is a clean approach and will avoid any confusion as the application grows.

This component is also wrapped in the `<Link />` component, which will give us the simple task of calling the below code to render it: 

```
import SocialIcon from '../SocialIcon';

...

<SocialIcon 
  socialUrl="https://github.com"
  iconType="facebook"
  iconSize='2x'
/>
```