### PR TITLE
Integrate socialIconGroup, utilizing dynamic JSON data

### DIFF
--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -8,16 +8,14 @@ class PortfolioApp extends Component {
   render() {
 
     const socialMediaAccounts = [
-      { socialMediaOutlet: "GitHub", socialUrl: "https://github.com/JesseNoseworthy" },
-      { socialMediaOutlet: "Twitter", socialUrl: "https://twitter.com/JesseNoseworthy" },
-      { socialMediaOutlet: "Medium", socialUrl: "https://medium.com/@JesseNoseworthy" },
-      { socialMediaOutlet: "Gmail", socialUrl: "mailto:noseworthyjesse@gmail.com"  }
+      { type: "GitHub", socialUrl: "https://github.com/JesseNoseworthy" },
+      { type: "Twitter", socialUrl: "https://twitter.com/JesseNoseworthy" },
+      { type: "Medium", socialUrl: "https://medium.com/@JesseNoseworthy" },
+      { type: "mail", socialUrl: "mailto:noseworthyjesse@gmail.com" }
     ] 
     return (
       <div className={styles.PortfolioApp}>
-        <Hero />
-        <SocialIconGroup 
-          socialMediaAccounts={socialMediaAccounts} />
+        <SocialIconGroup socialMediaAccounts={socialMediaAccounts} />
       </div>
     )
   }

--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -11,7 +11,7 @@ class PortfolioApp extends Component {
       { type: "GitHub", socialUrl: "https://github.com/JesseNoseworthy" },
       { type: "Twitter", socialUrl: "https://twitter.com/JesseNoseworthy" },
       { type: "Medium", socialUrl: "https://medium.com/@JesseNoseworthy" },
-      { type: "mail", socialUrl: "mailto:noseworthyjesse@gmail.com" }
+      { type: "email", socialUrl: "mailto:noseworthyjesse@gmail.com" }
     ] 
     return (
       <div className={styles.PortfolioApp}>

--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -2,12 +2,20 @@ import React, { Component } from 'react';
 import styles from './PortfolioApp.scss';
 import globalStyles from '../../globalStyles/index.scss';
 import Hero from '../Hero';
+import SocialIconGroup from '../SocialIconGroup';
 
 class PortfolioApp extends Component {
   render() {
+
+    const socialMediaAccounts = [
+      {category: 'Sporting Goods', price: '$49.99', stocked: true, name: 'Football'},
+      {category: 'Sporting Goods', price: '$49.99', stocked: true, name: 'Football'}
+    ]
     return (
       <div className={styles.PortfolioApp}>
         <Hero />
+        <SocialIconGroup 
+          social={socialMediaAccounts} />
       </div>
     )
   }

--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -8,14 +8,16 @@ class PortfolioApp extends Component {
   render() {
 
     const socialMediaAccounts = [
-      {category: 'Sporting Goods', price: '$49.99', stocked: true, name: 'Football'},
-      {category: 'Sporting Goods', price: '$49.99', stocked: true, name: 'Football'}
-    ]
+      { socialMediaOutlet: "GitHub", socialUrl: "https://github.com/JesseNoseworthy" },
+      { socialMediaOutlet: "Twitter", socialUrl: "https://twitter.com/JesseNoseworthy" },
+      { socialMediaOutlet: "Medium", socialUrl: "https://medium.com/@JesseNoseworthy" },
+      { socialMediaOutlet: "Gmail", socialUrl: "mailto:noseworthyjesse@gmail.com"  }
+    ] 
     return (
       <div className={styles.PortfolioApp}>
         <Hero />
         <SocialIconGroup 
-          social={socialMediaAccounts} />
+          socialMediaAccounts={socialMediaAccounts} />
       </div>
     )
   }

--- a/src/components/SocialIcon/index.js
+++ b/src/components/SocialIcon/index.js
@@ -20,7 +20,7 @@ class SocialIcon extends Component {
       <Link href={socialUrl} {...others}>
         <FontAwesome
           className={iconClass}
-          name={iconType}
+          name={iconType.toLowerCase()}
           size={iconSize}
          />
       </Link>

--- a/src/components/SocialIcon/index.js
+++ b/src/components/SocialIcon/index.js
@@ -29,7 +29,7 @@ class SocialIcon extends Component {
 }
 
 SocialIcon.propTypes = {
-  socailUrl: React.PropTypes.string,
+  socialUrl: React.PropTypes.string,
   variant: React.PropTypes.string,
   iconType: React.PropTypes.string.isRequired,
   iconSize: React.PropTypes.any,

--- a/src/components/SocialIconGroup/index.js
+++ b/src/components/SocialIconGroup/index.js
@@ -1,0 +1,28 @@
+// This component will render a FaceBook, Twitter, LinkedIn, and GitHub icon
+
+import React, { Component } from 'react';
+import { map, trim } from 'lodash';
+import styles from './SocialIconGroup.scss';
+import classNames from 'classnames';
+import SocialIcon from '../SocialIcon';
+
+class SocialIconGroup extends Component {
+  getSocialAccounts(social) {
+    // Loop through {social} and output an icon for each
+  }
+  render() {
+    const {
+      social,
+      ...others
+    } = this.props;
+
+    return (
+      <div {...others}>
+        <h1>SocialIconGroup</h1>
+        {this.getSocialAccounts(social)}
+      </div>
+    )
+  }
+}
+
+export default SocialIconGroup;

--- a/src/components/SocialIconGroup/index.js
+++ b/src/components/SocialIconGroup/index.js
@@ -15,7 +15,7 @@ class SocialIconGroup extends Component {
     return (
       <div {...others}>
         {socialMediaAccounts.map(function(name, i){
-          const getSocialType = socialMediaAccounts[i].type == 'mail' ? 'envelope' : socialMediaAccounts[i].type;
+          const getSocialType = socialMediaAccounts[i].type == 'email' ? 'envelope' : socialMediaAccounts[i].type;
           return (
             <SocialIcon 
               key={i}

--- a/src/components/SocialIconGroup/index.js
+++ b/src/components/SocialIconGroup/index.js
@@ -7,19 +7,45 @@ import classNames from 'classnames';
 import SocialIcon from '../SocialIcon';
 
 class SocialIconGroup extends Component {
-  getSocialAccounts(social) {
-    // Loop through {social} and output an icon for each
-  }
+  // getSocialAccounts(socialMediaAccounts) {
+  //   return (
+  //     {socialMediaAccounts.map(function(name, i){
+  //       return (
+  //         <SocialIcon 
+  //           key={i}
+  //           iconType={socialMediaAccounts[i].socialMediaOutlet}
+  //           socialUrl={socialMediaAccounts[i].socialUrl}
+  //           iconSize='2x'
+  //         />
+  //       );
+  //     })}
+  //   )
+  // };
   render() {
     const {
-      social,
+      socialMediaAccounts,
       ...others
     } = this.props;
 
     return (
       <div {...others}>
         <h1>SocialIconGroup</h1>
-        {this.getSocialAccounts(social)}
+        <SocialIcon 
+          socialUrl="https://github.com"
+          iconType="facebook"
+          iconSize='2x'
+        />
+        {socialMediaAccounts.map(function(name, i){
+          return (
+            <SocialIcon 
+              key={i}
+              // iconType={socialMediaAccounts[i].socialMediaOutlet}
+              iconType="test"
+              socialUrl={socialMediaAccounts[i].socialUrl}
+              iconSize='2x'
+            />
+          );
+        })}
       </div>
     )
   }

--- a/src/components/SocialIconGroup/index.js
+++ b/src/components/SocialIconGroup/index.js
@@ -7,40 +7,19 @@ import classNames from 'classnames';
 import SocialIcon from '../SocialIcon';
 
 class SocialIconGroup extends Component {
-  // getSocialAccounts(socialMediaAccounts) {
-  //   return (
-  //     {socialMediaAccounts.map(function(name, i){
-  //       return (
-  //         <SocialIcon 
-  //           key={i}
-  //           iconType={socialMediaAccounts[i].socialMediaOutlet}
-  //           socialUrl={socialMediaAccounts[i].socialUrl}
-  //           iconSize='2x'
-  //         />
-  //       );
-  //     })}
-  //   )
-  // };
   render() {
     const {
       socialMediaAccounts,
       ...others
     } = this.props;
-
     return (
       <div {...others}>
-        <h1>SocialIconGroup</h1>
-        <SocialIcon 
-          socialUrl="https://github.com"
-          iconType="facebook"
-          iconSize='2x'
-        />
         {socialMediaAccounts.map(function(name, i){
+          const getSocialType = socialMediaAccounts[i].type == 'mail' ? 'envelope' : socialMediaAccounts[i].type;
           return (
             <SocialIcon 
               key={i}
-              // iconType={socialMediaAccounts[i].socialMediaOutlet}
-              iconType="test"
+              iconType={getSocialType}
               socialUrl={socialMediaAccounts[i].socialUrl}
               iconSize='2x'
             />


### PR DESCRIPTION
This PR will enable the ability to directly pass JSON into the newly created `socialIconGroup` component to render multiple icons. This data is passed in as a prop and is then mapped through and rendered accordingly.

I've also included a couple of failsafes to accommodate for bad data:
- All data passed into `iconType` will be converted to a lowercase string at the components root
- Since FontAwesome doesn't contain an icon with the string of "email", if the type of account passed in is an email I'll convert it to the existing FontAwesome icon of "envelope" 

---

Moving forward off of this PR, I plan to create a global data script from within `../app`. This will hold all content and the rest will be controlled via props from within the `PortfolioApp` component. 