### PR TITLE
Resolve globalStyles import 

### DIFF
--- a/src/components/PortfolioApp/PortfolioApp.js
+++ b/src/components/PortfolioApp/PortfolioApp.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import styles from './PortfolioApp.scss';
-import globalStyles from '../../globalStyles/index.scss';
+import '../../globalStyles/index.scss';
 import SocialIconGroup from '../SocialIconGroup';
 import appData from '../../app/data/data.json';
 


### PR DESCRIPTION
This stylesheet is intended to be compiled into the global application file and only used in that regard. Therefore, a simple import of the file is all that is required. 

```
import globalStyles from '../../globalStyles/index.scss';

---> 

import '../../globalStyles/index.scss';
```

---

_This PR solves all previous linting errors_